### PR TITLE
turn off himawari before setting other layers

### DIFF
--- a/examples/webgl-timemachine/index.html
+++ b/examples/webgl-timemachine/index.html
@@ -211,7 +211,7 @@
       function loadHimawari() {
         if (!$("#show-himawari").prop('checked')) {
           $('#show-himawari').prop('checked', true);
-          timelapse.loadNewTimeline("himawari-times.json","defaultUI");
+          requestNewTimeline("himawari-times.json","defaultUI");
           showHimawariTimeMachineLayer = true;
           var v = timelapse.getVideoset();
           v.setFps(12);
@@ -280,6 +280,21 @@
             }
           });
         }
+      }
+
+      // Wait until currrent execution finishes so that we can skip loading the timeline in case it is not the last call.
+      // We do this because the timeline loads asynchronously; otherwise, the next waypoint might use the wrong timeline.
+      var finalizeNewTimelineTimeout = null;
+      function requestNewTimeline(url, newTimelineStyle) {
+        // The last timeline request takes precedence
+        if (finalizeNewTimelineTimeout !== null) {
+          clearTimeout(finalizeNewTimelineTimeout);
+          finalizeNewTimelineTimeout = null;
+        }
+        finalizeNewTimelineTimeout = setTimeout(function () {
+          timelapse.loadNewTimeline(url, newTimelineStyle);
+          finalizeNewTimelineTimeout = null;
+        }, 0);
       }
 
       function initLayerToggleUI() {
@@ -395,7 +410,7 @@
             return;
           }
           if ($(this).prop('checked')) {
-            timelapse.loadNewTimeline("forest-alerts-times.json","defaultUI");
+            requestNewTimeline("forest-alerts-times.json","defaultUI");
             showForestAlertsTimeMachineLayer = true;
             if ($("#show-forest-change").prop('checked')) {
               $("#show-forest-change").click();
@@ -419,7 +434,7 @@
           } else {
             showForestAlertsTimeMachineLayer = false;
             if (!showForestAlertsNoOverlayTimeMachineLayer && !showForestAlertsTimeMachineLayer) {
-              timelapse.loadNewTimeline("landsat-times-long.json","customUI");
+              requestNewTimeline("landsat-times-long.json","customUI");
               visibleBaseMapLayer = $("input:radio[name=base-layers]:checked").val();
               timelapse.setMaxScale(landsatMaxScale);
               var v = timelapse.getVideoset();
@@ -437,7 +452,7 @@
             return;
           }
           if ($(this).prop('checked')) {
-            timelapse.loadNewTimeline("forest-alerts-times.json","defaultUI");
+            requestNewTimeline("forest-alerts-times.json","defaultUI");
             showForestAlertsNoOverlayTimeMachineLayer = true;
             if ($("#show-forest-change").prop('checked')) {
               $("#show-forest-change").click();
@@ -461,7 +476,7 @@
           } else {
             showForestAlertsNoOverlayTimeMachineLayer = false;
             if (!showForestAlertsNoOverlayTimeMachineLayer && !showForestAlertsTimeMachineLayer) {
-              timelapse.loadNewTimeline("landsat-times-long.json","customUI");
+              requestNewTimeline("landsat-times-long.json","customUI");
               visibleBaseMapLayer = $("input:radio[name=base-layers]:checked").val();
               timelapse.setMaxScale(landsatMaxScale);
               var v = timelapse.getVideoset();
@@ -476,14 +491,14 @@
           if ($(this).prop('checked')) {
             showViirsLayer = true;
             timelapse.setPlaybackRate(8);
-            timelapse.loadNewTimeline("../createlab-viirs/viirs-times.json","defaultUI");
+            requestNewTimeline("../createlab-viirs/viirs-times.json","defaultUI");
             timelapse.setDoDwell(false);
             $("#show-additional-landsat").prop("disabled", true);
             $("#fires-at-night-legend").show();
           } else {
             showViirsLayer = false;
             timelapse.setPlaybackRate(defaultPlaybackSpeed);
-            timelapse.loadNewTimeline("landsat-times-long.json","customUI");
+            requestNewTimeline("landsat-times-long.json","customUI");
             timelapse.setDoDwell(true);
             $("#show-additional-landsat").prop("disabled", false);
             $("#fires-at-night-legend").hide();
@@ -505,7 +520,7 @@
 
         $("#show-coral-bleaching-alerts").on("click", function() {
           if ($(this).prop('checked')) {
-            timelapse.loadNewTimeline("crw-times.json","defaultUI");
+            requestNewTimeline("crw-times.json","defaultUI");
             showCrwTimemachineLayer = true;
             showMcrmLayer = true;
             var v = timelapse.getVideoset();
@@ -517,7 +532,7 @@
           } else {
             showCrwTimemachineLayer = false;
             showMcrmLayer = false;
-            timelapse.loadNewTimeline("landsat-times-long.json","customUI");
+            requestNewTimeline("landsat-times-long.json","customUI");
             timelapse.setDoDwell(true);
             WebglVideoTile.useGreenScreen = false;
             var v = timelapse.getVideoset();
@@ -530,7 +545,7 @@
 
         $("#show-himawari").on("click", function() {
           if ($(this).prop('checked')) {
-            timelapse.loadNewTimeline("himawari-times.json","defaultUI");
+            requestNewTimeline("himawari-times.json","defaultUI");
             showHimawariTimeMachineLayer = true;
             var v = timelapse.getVideoset();
             v.setFps(12);
@@ -542,7 +557,7 @@
             $(".vector-legend").hide();
           } else {
             showHimawariTimeMachineLayer = false;
-            timelapse.loadNewTimeline("landsat-times-long.json","customUI");
+            requestNewTimeline("landsat-times-long.json","customUI");
             var v = timelapse.getVideoset();
             v.setFps(10);
             visibleBaseMapLayer = previousVisibleBaseMapLayer;
@@ -1289,6 +1304,9 @@
             if ($waterChangeToggle.prop('checked')) {
               $waterChangeToggle.click();
             }
+            if ($himawariLayerToggle.prop('checked') && himawariWaypointIndicies.indexOf(waypointIndex) === -1) {
+              $himawariLayerToggle.click();
+            }
 
             //// Set layers based on selected waypoint ////
 
@@ -1370,9 +1388,6 @@
             } else if (waypointIndex == himawariWaypointIndicies[10]) {
               waypointBounds = timelapse.pixelCenterToPixelBoundingBoxView({x: 745253.433241357, y: 550139.9045414061, scale: 0.006365420067946737}).bbox;
               setHimawariView(waypointBounds, 223.084, 0.5);
-            } else {
-              if ($himawariLayerToggle.prop('checked'))
-                $himawariLayerToggle.click();
             }
             // End Himawari
 


### PR DESCRIPTION
Himawari Layer isn't turned off properly if it isn't unchecked before a new waypoint is set. This results in weird behavior when the user accesses waypoints that changed capture times, timeline UI, FPS, base map, max scale, dwell, or playback rate. 

Repro steps: 
1. Start data-visualization-tools
2. Turn on the Himawari-8 layer
3. Switch to "Agricultural Fires" slide
4. Observe wrong base map layer and animation

This commit is intended to fix the issue. 